### PR TITLE
Set default aliases for plugins, modules, and root app

### DIFF
--- a/src/Composer.php
+++ b/src/Composer.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace craft\cloud;
+
+use Craft;
+use craft\helpers\Json;
+use Illuminate\Support\Collection;
+use League\Uri\Components\HierarchicalPath;
+
+class Composer
+{
+    public static function getPluginAliases(): Collection
+    {
+        $path = HierarchicalPath::fromAbsolute(
+            Craft::$app->getVendorPath(),
+            'craftcms/plugins.php',
+        );
+
+        if (!file_exists($path)) {
+            return new Collection();
+        }
+
+        $plugins = require $path;
+
+        return Collection::make($plugins)
+            ->flatMap(fn(array $plugin) => $plugin['aliases'] ?? []);
+    }
+
+    public static function getModuleAliases(): Collection
+    {
+        $data = Json::decode(file_get_contents(Craft::$app->getComposer()->getLockPath()));
+        $packages = new Collection($data['packages'] ?? null);
+
+        return $packages
+            ->where('type', 'yii-module')
+            ->flatMap(function($package) {
+                $packageName = $package['name'] ?? null;
+
+                if (!$packageName) {
+                    return null;
+                }
+
+                $basePath = HierarchicalPath::fromAbsolute(
+                    Craft::$app->getVendorPath(),
+                    $packageName,
+                );
+
+                return static::psr4ToAliases(
+                    $package['autoload']['psr-4'] ?? [],
+                    $basePath,
+                );
+            });
+    }
+
+    public static function getRootAliases(): Collection
+    {
+        $jsonPath = Craft::$app->getComposer()->getJsonPath();
+        $root = dirname($jsonPath);
+        $data = Json::decode(file_get_contents($jsonPath));
+
+        return static::psr4ToAliases(
+            $data['autoload']['psr-4'] ?? [],
+            $root,
+        );
+    }
+
+    protected static function psr4ToAliases(iterable $psr4, string $basePath): Collection
+    {
+        return Collection::make($psr4)
+            ->mapWithKeys(function($path, $namespace) use ($basePath) {
+
+                // Yii doesn't support aliases that point to multiple base paths
+                if (is_array($path)) {
+                    return null;
+                }
+
+                $normalizedPath = HierarchicalPath::new($path);
+
+                if (!$normalizedPath->isAbsolute()) {
+                    $normalizedPath = HierarchicalPath::fromAbsolute(
+                        $basePath,
+                        $path,
+                    );
+                }
+
+                $alias = '@' . str_replace('\\', '/', trim($namespace, '\\'));
+                $normalizedPath = $normalizedPath->withoutTrailingSlash()->value();
+
+                return [$alias => $normalizedPath];
+            });
+    }
+}

--- a/src/cli/controllers/AssetBundlesController.php
+++ b/src/cli/controllers/AssetBundlesController.php
@@ -58,7 +58,9 @@ class AssetBundlesController extends Controller
                 $rc = new ReflectionClass($className);
 
                 if (!$rc->isSubclassOf(AssetBundle::class) || !$rc->isInstantiable()) {
-                    throw new Exception('Not a valid asset bundle.');
+                    // TODO: enhance \craft\console\Controller::do to return
+                    // non-error responses (skip)
+                    return;
                 }
 
                 /** @var AssetBundle $assetBundle */


### PR DESCRIPTION
When `CRAFT_NO_DB`, set aliases for:
- plugins, `using craftcms/plugins.php`
- `yii-module` packages from `composer.lock`
- `autoload.psr-4` in root `composer.json`

This mimicks the behavior from the [plugin installer](https://github.com/craftcms/plugin-installer/blob/master/src/Installer.php#L291).