### PR TITLE
Add artifactBaseUrl

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -13,6 +13,7 @@ use League\Uri\Uri;
  */
 class Config extends BaseConfig
 {
+    public ?string $artifactBaseUrl = null;
     public array $s3ClientOptions = [];
     public string $cdnBaseUrl = 'https://cdn.craft.cloud';
     public ?string $sqsUrl = null;

--- a/src/fs/BuildArtifactsFs.php
+++ b/src/fs/BuildArtifactsFs.php
@@ -13,6 +13,7 @@ class BuildArtifactsFs extends BuildsFs
     public function init(): void
     {
         $this->useLocalFs = !Module::getInstance()->getConfig()->getUseArtifactCdn();
+        $this->localFsUrl = Module::getInstance()->getConfig()->artifactBaseUrl ?? $this->localFsUrl;
         parent::init();
     }
 

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -95,6 +95,7 @@ abstract class Fs extends FlysystemFs
         }
     }
 
+    // TODO: return URI type
     public function createUrl(string $path = ''): string
     {
         $baseUrl = $this->useLocalFs


### PR DESCRIPTION
@AugustMiller can you try this branch and see how it feels `dev-artifactBaseUrl`?

You can set `CRAFT_CLOUD_ARTIFACT_BASE_URL` in env, or `artifactBaseUrl` in `config/cloud.php`.
Then you should be able to drop your ternary and use `artifactUrl` everywhere.

Related: https://github.com/craftcms/cloud-extension-yii2/issues/15