### PR TITLE
Update minimum required Craft version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When installed, the extension automatically [bootstraps](https://www.yiiframewor
 
 ## Installation
 
-The Cloud extension can be installed in any existing Craft 4.5+ project by running `php craft setup/cloud`. Craft will add the `craftcms/cloud` package and run the extension’s own setup wizard.
+The Cloud extension can be installed in any existing Craft 4.6+ project by running `php craft setup/cloud`. Craft will add the `craftcms/cloud` package and run the extension’s own setup wizard.
 
 > [!TIP]
 > This process includes the creation of a [`craft-cloud.yaml` configuration file](https://craftcms.com/knowledge-base/cloud-config) which helps Cloud understand your project’s structure and determines which versions of PHP and Node your project will use during builds and at runtime.


### PR DESCRIPTION
This PR updates the minimum required Craft version to `4.6+`, since that’s what is required in `composer.json`.
https://github.com/craftcms/cloud-extension-yii2/blob/a7ae9f10bf5f700217725e7034f65f6b74a79285/composer.json#L10