### PR TITLE
Remove backtick from `cloud-config.yaml`

### DIFF
--- a/src/cli/controllers/SetupController.php
+++ b/src/cli/controllers/SetupController.php
@@ -147,7 +147,7 @@ class SetupController extends Controller
             ]);
         }
 
-        $output = "# Craft Cloud configuration file`\n";
+        $output = "# Craft Cloud configuration file\n";
         $output .= "# https://craftcms.com/knowledge-base/cloud-config\n";
         $output .= Yaml::dump($config, 20, 2);
 


### PR DESCRIPTION
This PR removes a stray backtick from the config setup process which was subsequently causing deploys to fail.