### PR TITLE
Improved invalidation

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -3,6 +3,7 @@
 namespace craft\cloud;
 
 use Craft;
+use craft\base\Element;
 use craft\base\Event;
 use craft\base\Model;
 use craft\cloud\fs\AssetsFs;
@@ -217,25 +218,37 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
         Event::on(
             View::class,
             View::EVENT_BEFORE_RENDER_PAGE_TEMPLATE,
-            [$this->get('staticCache'), 'handleBeforeRenderPageTemplate'],
+            [$this->getStaticCache(), 'handleBeforeRenderPageTemplate'],
         );
 
         Event::on(
             View::class,
             View::EVENT_AFTER_RENDER_PAGE_TEMPLATE,
-            [$this->get('staticCache'), 'handleAfterRenderPageTemplate'],
+            [$this->getStaticCache(), 'handleAfterRenderPageTemplate'],
         );
 
         Event::on(
             Elements::class,
             Elements::EVENT_INVALIDATE_CACHES,
-            [$this->get('staticCache'), 'handleInvalidateCaches'],
+            [$this->getStaticCache(), 'handleInvalidateCaches'],
         );
 
         Event::on(
             ClearCaches::class,
             ClearCaches::EVENT_REGISTER_CACHE_OPTIONS,
-            [$this->get('staticCache'), 'handleRegisterCacheOptions'],
+            [$this->getStaticCache(), 'handleRegisterCacheOptions'],
+        );
+
+        Event::on(
+            Element::class,
+            Element::EVENT_AFTER_SAVE,
+            [$this->getStaticCache(), 'handleAfterUpdate'],
+        );
+
+        Event::on(
+            Element::class,
+            Element::EVENT_AFTER_DELETE,
+            [$this->getStaticCache(), 'handleAfterUpdate'],
         );
 
         Event::on(

--- a/src/Module.php
+++ b/src/Module.php
@@ -3,7 +3,6 @@
 namespace craft\cloud;
 
 use Craft;
-use craft\base\Element;
 use craft\base\Event;
 use craft\base\Model;
 use craft\cloud\fs\AssetsFs;
@@ -21,10 +20,8 @@ use craft\fs\Temp;
 use craft\helpers\App;
 use craft\imagetransforms\FallbackTransformer;
 use craft\imagetransforms\ImageTransformer as CraftImageTransformer;
-use craft\services\Elements;
 use craft\services\Fs as FsService;
 use craft\services\ImageTransforms;
-use craft\utilities\ClearCaches;
 use craft\web\Application as WebApplication;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\View;
@@ -197,41 +194,7 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
 
     protected function registerCloudEventHandlers(): void
     {
-        Event::on(
-            View::class,
-            View::EVENT_BEFORE_RENDER_PAGE_TEMPLATE,
-            [$this->getStaticCache(), 'handleBeforeRenderPageTemplate'],
-        );
-
-        Event::on(
-            View::class,
-            View::EVENT_AFTER_RENDER_PAGE_TEMPLATE,
-            [$this->getStaticCache(), 'handleAfterRenderPageTemplate'],
-        );
-
-        Event::on(
-            Elements::class,
-            Elements::EVENT_INVALIDATE_CACHES,
-            [$this->getStaticCache(), 'handleInvalidateCaches'],
-        );
-
-        Event::on(
-            ClearCaches::class,
-            ClearCaches::EVENT_REGISTER_CACHE_OPTIONS,
-            [$this->getStaticCache(), 'handleRegisterCacheOptions'],
-        );
-
-        Event::on(
-            Element::class,
-            Element::EVENT_AFTER_SAVE,
-            [$this->getStaticCache(), 'handleAfterUpdate'],
-        );
-
-        Event::on(
-            Element::class,
-            Element::EVENT_AFTER_DELETE,
-            [$this->getStaticCache(), 'handleAfterUpdate'],
-        );
+        $this->getStaticCache()->registerEventHandlers();
 
         Event::on(
             Asset::class,

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -18,6 +18,19 @@ use samdark\log\PsrMessage;
 use yii\base\Event;
 use yii\caching\TagDependency;
 
+/**
+ * Static Cache tags can appear in the `Cache-Tag` and `Cache-Purge-Tag` headers.
+ * The values are comma-separated and can be in several formats:
+ *
+ * - Added by the gateway:
+ *   - `{environmentId}`
+ *   - `{environmentId}:{uri}` (URI must have a leading and no trailing slash)
+ * - Added by the CDN:
+ *    - `cdn:{environmentId}`
+ *    - `cdn:{environmentId}:{objectPath}`
+ * - Added by Craft:
+ *   - `{environmentShortId}{hashed}`
+ */
 class StaticCache extends \yii\base\Component
 {
     public const CDN_PREFIX = 'cdn:';

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -12,7 +12,6 @@ use craft\web\Response as WebResponse;
 use craft\web\UrlManager;
 use craft\web\View;
 use Illuminate\Support\Collection;
-use League\Uri\Uri;
 use samdark\log\PsrMessage;
 use yii\base\Event;
 use yii\caching\TagDependency;
@@ -108,7 +107,6 @@ class StaticCache extends \yii\base\Component
     public function purgePrefixes(string ...$prefixes): void
     {
         $prefixesForHeader = Collection::make($prefixes)
-            ->map(fn(string $prefix) => $this->urlToPrefix($prefix))
             ->filter()
             ->unique()
             ->values();
@@ -169,18 +167,6 @@ class StaticCache extends \yii\base\Component
                 HeaderEnum::CACHE_PURGE_TAG->value => $tagsForHeader->implode(','),
             ]);
         }
-    }
-
-    protected function urlToPrefix(string $url): string
-    {
-        $uri = Uri::new($url);
-        $host = $uri->getHost();
-
-        if (!$host) {
-            throw new \InvalidArgumentException('Invalid URL');
-        }
-
-        return $host . $uri->getPath();
     }
 
     protected function prepareTags(iterable $tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -7,7 +7,6 @@ use craft\events\ElementEvent;
 use craft\events\InvalidateElementCachesEvent;
 use craft\events\RegisterCacheOptionsEvent;
 use craft\events\TemplateEvent;
-use craft\helpers\ElementHelper;
 use craft\services\Elements;
 use craft\utilities\ClearCaches;
 use craft\web\UrlManager;
@@ -19,6 +18,19 @@ use yii\caching\TagDependency;
 
 class StaticCache extends \yii\base\Component
 {
+    private ?int $cacheDuration = null;
+    private Collection $elementTags;
+    private Collection $tags;
+    // private Collection $purgeElementTags;
+    // private Collection $purgeTags;
+    // private Collection $purgeUrlPrefixes;
+
+    public function init(): void
+    {
+        $this->tags = new Collection();
+        $this->elementTags = new Collection();
+    }
+
     public function registerEventHandlers(): void
     {
         Event::on(
@@ -66,44 +78,23 @@ class StaticCache extends \yii\base\Component
 
     public function handleInitWebApplication(Event $event): void
     {
-        if (!$this->shouldBeCacheable()) {
-            return;
-        }
-
         Craft::$app->getElements()->startCollectingCacheInfo();
     }
 
     public function handleAfterPrepareWebResponse(Event $event): void
     {
-        if (!$this->shouldBeCacheable()) {
-            return;
-        }
-
         /** @var TagDependency|null $dependency */
         /** @var int|null $duration */
         [$dependency, $duration] = Craft::$app->getElements()->stopCollectingCacheInfo();
         $elementTags = $dependency?->tags ?? [];
-        $preparedElementTags = $this->prepareElementTags(...$elementTags);
-        $duration = $duration ?? Craft::$app->getConfig()->getGeneral()->cacheDuration;
+        $this->elementTags->push(...$elementTags);
+        $this->cacheDuration = $this->cacheDuration ?? $duration;
 
-        Craft::info(new PsrMessage('Adding cache headers to response', [
-            'duration' => $duration,
-        ]));
-
-        Craft::$app->getResponse()->setCacheHeaders(
-            $duration ?? Craft::$app->getConfig()->getGeneral()->cacheDuration,
-            false,
-        );
-
-        $this->addTags(...$preparedElementTags);
+        $this->addCacheHeadersToResponse();
     }
 
     public function handleBeforeRenderPageTemplate(TemplateEvent $event): void
     {
-        if (!$this->shouldBeCacheable()) {
-            return;
-        }
-
         /** @var UrlManager $urlManager */
         $urlManager = Craft::$app->getUrlManager();
         $matchedElement = $urlManager->getMatchedElement();
@@ -116,18 +107,13 @@ class StaticCache extends \yii\base\Component
     public function handleInvalidateElementCaches(InvalidateElementCachesEvent $event): void
     {
         $tags = $this->prepareElementTags(...$event->tags);
-
-        if ($tags->isEmpty()) {
-            return;
-        }
-
         $this->purgeTags(...$tags);
     }
 
     public function handleRegisterCacheOptions(RegisterCacheOptionsEvent $event): void
     {
         $event->options[] = [
-            'key' => 'cloud-caches',
+            'key' => 'craft-cloud-caches',
             'label' => Craft::t('app', 'Craft Cloud caches'),
             'action' => [$this, 'purgeAll'],
         ];
@@ -138,7 +124,7 @@ class StaticCache extends \yii\base\Component
         $element = $event->element;
         $url = $element->getUrl();
 
-        if (ElementHelper::isDraftOrRevision($element) || !$url) {
+        if (!$url) {
             return;
         }
 
@@ -150,176 +136,44 @@ class StaticCache extends \yii\base\Component
         $this->purgeTags(Module::getInstance()->getConfig()->environmentId);
     }
 
-    public function purgeUrlPrefixes(string ...$urlPrefixes): void
+    private function addCacheHeadersToResponse(): void
     {
-        $this->purgeItemsByHeader(
-            HeaderEnum::CACHE_PURGE_PREFIX->value,
-            ...$urlPrefixes,
-        );
-    }
+        $this->cacheDuration = $this->cacheDuration ?? Craft::$app->getConfig()->getGeneral()->cacheDuration;
 
-    public function purgeTags(string ...$tags): void
-    {
-        $this->purgeItemsByHeader(
-            HeaderEnum::CACHE_PURGE_TAG->value,
-            ...$tags,
-        );
-    }
-
-    public function getTags(): Collection
-    {
-        if (!$this->shouldBeCacheable()) {
-            return new Collection();
-        }
-
-        $tags = Craft::$app
-            ->getResponse()
-            ->getHeaders()
-            ->get(HeaderEnum::CACHE_TAG->value, first: false) ?? [];
-
-        return new Collection($tags);
-    }
-
-    public function addTags(string ...$tags): void
-    {
-        if (!$this->shouldBeCacheable()) {
-            return;
-        }
-
-        $headers = Craft::$app->getResponse()->getHeaders();
-        $tags = $this->prepareTagsForResponse(
-            Module::getInstance()->getConfig()->environmentId,
-            ...$this->getTags(),
-            ...$tags,
-        );
-
-        Craft::info(new PsrMessage('Adding tags to {header} header', [
-            'header' => HeaderEnum::CACHE_TAG->value,
-            'tags' => $tags->all(),
+        Craft::info(new PsrMessage('Setting cache headers', [
+            'duration' => $this->cacheDuration,
         ]));
 
-        $headers->remove(HeaderEnum::CACHE_TAG->value);
-        $tags->each(fn(string $tag) => $headers->add(
+        Craft::$app->getResponse()->setCacheHeaders(
+            $this->cacheDuration,
+            false,
+        );
+
+        // TODO: Add tags to the response headers
+        $headers = Craft::$app->getResponse()->getHeaders();
+        $this->tags->each(fn(string $tag) => $headers->add(
+            HeaderEnum::CACHE_TAG->value,
+            $tag,
+        ));
+        $this->elementTags->each(fn(string $tag) => $headers->add(
             HeaderEnum::CACHE_TAG->value,
             $tag,
         ));
     }
 
-    public function removeTags(string ...$tags): void
+    private function purgeTags(string ...$tags): void
     {
-        if (!$this->shouldBeCacheable()) {
-            return;
-        }
-
-        $tags = $this->getTags()->diff($tags);
-
-        Craft::info(new PsrMessage('Removing tags from {header} header', [
-            'tags' => $tags->all(),
-        ]));
-
-        $headers = Craft::$app->getResponse()->getHeaders();
-        $headers->remove(HeaderEnum::CACHE_TAG->value);
-        $tags->each(fn(string $tag) => $headers->add(
-            HeaderEnum::CACHE_TAG->value,
-            $tag,
-        ));
+        // ensure everything starts with env prefix
+        // however, the gateway could/should do this as well
     }
 
-    private function purgeItemsByHeader($header, ...$items): void
+    private function purgeUrlPrefixes(string ...$urls): void
     {
-        $items = Collection::make($items);
-        $response = Craft::$app->getResponse();
-        $isWebResponse = $response instanceof \craft\web\Response;
-
-        if ($isWebResponse) {
-            $existingTags = $response->getHeaders()->get($header, first: false) ?? [];
-            $items->push(...$existingTags);
-        }
-
-        $items = $items->filter()->unique();
-
-        if ($items->isEmpty()) {
-            return;
-        }
-
-        Craft::info(new PsrMessage('Purging items via {header}', [
-            'items' => $items->all(),
-            'header' => $header,
-        ]));
-
-        if ($isWebResponse) {
-            $response->getHeaders()->remove($header);
-            $items->each(fn(string $tag) => $response->getHeaders()->add(
-                $header,
-                $tag,
-            ));
-        } else {
-            Helper::makeGatewayApiRequest([
-                $header => $items->implode(','),
-            ]);
-        }
-    }
-
-    private function prepareTagsForResponse(string ...$tags): Collection
-    {
-        // Header value can't exceed 16KB
-        // https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
-        $bytes = 0;
-
-        return Collection::make($tags)
-            ->map(fn(string $tag) => $this->removeNonPrintableChars($tag))
-            ->filter()
-            ->unique()
-            ->filter(function($tag) use (&$bytes) {
-                // plus one for comma
-                $bytes += strlen($tag) + 1;
-
-                return $bytes < 16 * 1024;
-            })
-            ->values();
-    }
-
-    private function removeNonPrintableChars(string $string): string
-    {
-        return preg_replace('/[^[:print:]]/', '', $string);
-    }
-
-    private function hash(string $string): string
-    {
-        return sprintf('%x', crc32($string));
-    }
-
-    private function shouldBeCacheable(): bool
-    {
-        $response = Craft::$app->getResponse();
-
-        return
-            Craft::$app->getView()->templateMode === View::TEMPLATE_MODE_SITE &&
-            $response instanceof \craft\web\Response &&
-            !$response->getIsServerError();
     }
 
     private function prepareElementTags(string ...$tags): Collection
     {
-        if ($this->shouldIgnoreElementTags(...$tags)) {
-            Craft::info(new PsrMessage('Ignoring cache tags', [
-                'tags' => $tags,
-            ]));
-
-            return new Collection();
-        }
-
-        return Collection::make($tags)
-            ->sort(SORT_NATURAL)
-            ->map(function(string $tag) {
-                return Module::getInstance()->getConfig()->getShortEnvironmentId() . $this->hash($tag);
-            });
-    }
-
-    private function shouldIgnoreElementTags(string ...$tags): bool
-    {
-        return Collection::make($tags)->contains(function(string $tag) {
-            return preg_match('/element::craft\\\\elements\\\\\S+::(drafts|revisions)/', $tag);
-        });
+        // hash
+        return new Collection($tags);
     }
 }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -24,10 +24,10 @@ use yii\caching\TagDependency;
  *
  * - Added by the gateway:
  *   - `{environmentId}`
- *   - `{environmentId}:{uri}` (URI must have a leading and no trailing slash)
+ *   - `{environmentId}:{uri}` (URI has a leading and no trailing slash)
  * - Added by the CDN:
  *    - `cdn:{environmentId}`
- *    - `cdn:{environmentId}:{objectPath}`
+ *    - `cdn:{environmentId}:{objectKey}` (object key has no leading slash)
  * - Added by Craft:
  *   - `{environmentShortId}{hashed}`
  */

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -67,7 +67,7 @@ class StaticCache extends \yii\base\Component
         );
     }
 
-    private function handleInitWebApplication(Event $event): void
+    public function handleInitWebApplication(Event $event): void
     {
         if (!$this->shouldCollectCacheInfo()) {
             return;
@@ -76,7 +76,7 @@ class StaticCache extends \yii\base\Component
         Craft::$app->getElements()->startCollectingCacheInfo();
     }
 
-    private function handleBeforeSendResponse(Event $event): void
+    public function handleBeforeSendResponse(Event $event): void
     {
         if (!$this->shouldCollectCacheInfo()) {
             return;
@@ -91,7 +91,7 @@ class StaticCache extends \yii\base\Component
         }
     }
 
-    private function handleBeforeRenderPageTemplate(TemplateEvent $event): void
+    public function handleBeforeRenderPageTemplate(TemplateEvent $event): void
     {
         if (!$this->shouldCollectCacheInfo()) {
             return;
@@ -106,7 +106,7 @@ class StaticCache extends \yii\base\Component
         }
     }
 
-    private function handleAfterUpdate(Event $event): void
+    public function handleAfterUpdate(Event $event): void
     {
         /** @var Element $element */
         $element = $event->sender;
@@ -124,7 +124,7 @@ class StaticCache extends \yii\base\Component
         $this->purgePrefixes($url);
     }
 
-    private function handleInvalidateElementCaches(InvalidateElementCachesEvent $event): void
+    public function handleInvalidateElementCaches(InvalidateElementCachesEvent $event): void
     {
         $tags = $event->tags ?? [];
 
@@ -135,7 +135,7 @@ class StaticCache extends \yii\base\Component
         $this->purgeTags(...$tags);
     }
 
-    private function handleRegisterCacheOptions(RegisterCacheOptionsEvent $event): void
+    public function handleRegisterCacheOptions(RegisterCacheOptionsEvent $event): void
     {
         $event->options[] = [
             'key' => 'cloud-static-caches',

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -17,8 +17,6 @@ use yii\caching\TagDependency;
 
 class StaticCache extends \yii\base\Component
 {
-    private const CDN_TAG_PREFIX = 'cdn:';
-
     public function registerEventHandlers(): void
     {
         Event::on(
@@ -123,12 +121,7 @@ class StaticCache extends \yii\base\Component
 
     public function purgeAll(): void
     {
-        $environmentId = Module::getInstance()->getConfig()->environmentId;
-
-        $this->purgeTags(
-            $environmentId,
-            self::CDN_TAG_PREFIX . $environmentId,
-        );
+        $this->purgeTags(Module::getInstance()->getConfig()->environmentId);
     }
 
     public function purgeUrlPrefixes(string ...$urlPrefixes): void

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -20,6 +20,7 @@ use yii\caching\TagDependency;
 
 class StaticCache extends \yii\base\Component
 {
+    public const CDN_PREFIX = 'cdn:';
     private ?int $cacheDuration = null;
     private Collection $tags;
     private Collection $tagsToPurge;
@@ -162,9 +163,24 @@ class StaticCache extends \yii\base\Component
 
     public function purgeAll(): void
     {
+        $this->purgeCdn();
+        $this->purgeGateway();
+    }
+
+    public function purgeCdn(): void
+    {
         $tag = StaticCacheTag::create(
             Module::getInstance()->getConfig()->environmentId,
         )->minify(false);
+
+        $this->tagsToPurge->push($tag);
+    }
+
+    public function purgeGateway(): void
+    {
+        $tag = StaticCacheTag::create(
+            Module::getInstance()->getConfig()->environmentId,
+        )->withPrefix(self::CDN_PREFIX)->minify(false);
 
         $this->tagsToPurge->push($tag);
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -213,7 +213,7 @@ class StaticCache extends \yii\base\Component
         $isWebResponse = $response instanceof \craft\web\Response;
 
         if ($isWebResponse) {
-            $existingTags = $response->getHeaders()->get($header, first: false);
+            $existingTags = $response->getHeaders()->get($header, first: false) ?? [];
             $items->push(...$existingTags);
         }
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -176,11 +176,11 @@ class StaticCache extends \yii\base\Component
 
     public function purgeAll(): void
     {
-        $this->purgeCdn();
         $this->purgeGateway();
+        $this->purgeCdn();
     }
 
-    public function purgeCdn(): void
+    public function purgeGateway(): void
     {
         $tag = StaticCacheTag::create(
             Module::getInstance()->getConfig()->environmentId,
@@ -189,7 +189,7 @@ class StaticCache extends \yii\base\Component
         $this->tagsToPurge->push($tag);
     }
 
-    public function purgeGateway(): void
+    public function purgeCdn(): void
     {
         $tag = StaticCacheTag::create(
             Module::getInstance()->getConfig()->environmentId,

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -81,10 +81,10 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        // capture the matched element, if there was one
         /** @var UrlManager $urlManager */
         $urlManager = Craft::$app->getUrlManager();
         $matchedElement = $urlManager->getMatchedElement();
+
         if ($matchedElement) {
             Craft::$app->getElements()->collectCacheInfoForElement($matchedElement);
         }

--- a/src/StaticCacheTag.php
+++ b/src/StaticCacheTag.php
@@ -2,9 +2,9 @@
 
 namespace craft\cloud;
 
-class StaticCacheTag
+class StaticCacheTag implements \Stringable
 {
-    public string $originalValue;
+    public readonly string $originalValue;
     private bool $minify = true;
 
     public function __construct(

--- a/src/StaticCacheTag.php
+++ b/src/StaticCacheTag.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace craft\cloud;
+
+class StaticCacheTag
+{
+    public string $originalValue;
+    private bool $minify = true;
+
+    public function __construct(
+        private string $value,
+    ) {
+        $this->originalValue = $value;
+    }
+
+    public static function create(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function __toString(): string
+    {
+        return $this->getValue();
+    }
+
+    public function getValue(): string
+    {
+        if ($this->minify && !Module::getInstance()->getConfig()->getDevMode()) {
+            return $this
+                ->removeNonPrintableChars()
+                ->hash()
+                ->withPrefix(Module::getInstance()->getConfig()->getShortEnvironmentId())
+                ->value;
+        }
+
+        return $this->value;
+    }
+
+    public function withPrefix(string $prefix): self
+    {
+        $this->value = $prefix . $this->value;
+
+        return $this;
+    }
+
+    public function minify(bool $minify = true): self
+    {
+        $this->minify = $minify;
+
+        return $this;
+    }
+
+    private function removeNonPrintableChars(): self
+    {
+        $this->value = preg_replace('/[^[:print:]]/', '', $this->value);
+
+        return $this;
+    }
+
+    private function hash(): self
+    {
+        $this->value = sprintf('%x', crc32($this->value));
+
+        return $this;
+    }
+}

--- a/src/cli/controllers/StaticCacheController.php
+++ b/src/cli/controllers/StaticCacheController.php
@@ -11,7 +11,7 @@ class StaticCacheController extends Controller
     public function actionPurgePrefixes(string ...$prefixes): int
     {
         $this->do('Purging prefixes', function() use ($prefixes) {
-            Module::getInstance()->getStaticCache()->purgePrefixes(...$prefixes);
+            Module::getInstance()->getStaticCache()->purgeUrlPrefixes(...$prefixes);
         });
 
         return ExitCode::OK;

--- a/src/cli/controllers/StaticCacheController.php
+++ b/src/cli/controllers/StaticCacheController.php
@@ -2,10 +2,8 @@
 
 namespace craft\cloud\cli\controllers;
 
-use craft\cloud\HeaderEnum;
-use craft\cloud\Helper;
+use craft\cloud\Module;
 use craft\console\Controller;
-use Illuminate\Support\Collection;
 use yii\console\ExitCode;
 
 class StaticCacheController extends Controller
@@ -13,11 +11,7 @@ class StaticCacheController extends Controller
     public function actionPurgePrefixes(string ...$prefixes): int
     {
         $this->do('Purging prefixes', function() use ($prefixes) {
-            $headers = Collection::make([
-                HeaderEnum::CACHE_PURGE_PREFIX->value => implode(',', $prefixes),
-            ]);
-
-            Helper::makeGatewayApiRequest($headers);
+            Module::getInstance()->getStaticCache()->purgePrefixes(...$prefixes);
         });
 
         return ExitCode::OK;
@@ -26,11 +20,7 @@ class StaticCacheController extends Controller
     public function actionPurgeTags(string ...$tags): int
     {
         $this->do('Purging tags', function() use ($tags) {
-            $headers = Collection::make([
-                HeaderEnum::CACHE_PURGE_TAG->value => implode(',', $tags),
-            ]);
-
-            Helper::makeGatewayApiRequest($headers);
+            Module::getInstance()->getStaticCache()->purgeTags(...$tags);
         });
 
         return ExitCode::OK;

--- a/src/cli/controllers/UpController.php
+++ b/src/cli/controllers/UpController.php
@@ -3,6 +3,7 @@
 namespace craft\cloud\cli\controllers;
 
 use Craft;
+use craft\cloud\Module;
 use craft\console\Controller;
 use craft\events\CancelableEvent;
 use yii\console\ExitCode;
@@ -26,7 +27,7 @@ class UpController extends Controller
 
         if (Craft::$app->getIsInstalled()) {
             $this->run('/up');
-            $this->run('/clear-caches/craft-cloud-caches');
+            Module::getInstance()->getStaticCache()->purgeGateway();
         }
 
         $event = new CancelableEvent();

--- a/src/cli/controllers/UpController.php
+++ b/src/cli/controllers/UpController.php
@@ -26,7 +26,7 @@ class UpController extends Controller
 
         if (Craft::$app->getIsInstalled()) {
             $this->run('/up');
-            $this->run('/clear-caches/cloud-caches');
+            $this->run('/clear-caches/craft-cloud-caches');
         }
 
         $event = new CancelableEvent();

--- a/src/cli/controllers/UpController.php
+++ b/src/cli/controllers/UpController.php
@@ -26,7 +26,7 @@ class UpController extends Controller
 
         if (Craft::$app->getIsInstalled()) {
             $this->run('/up');
-            $this->run('/clear-caches/cloud-static-caches');
+            $this->run('/clear-caches/cloud-caches');
         }
 
         $event = new CancelableEvent();

--- a/src/fs/CdnFs.php
+++ b/src/fs/CdnFs.php
@@ -2,9 +2,8 @@
 
 namespace craft\cloud\fs;
 
-use craft\cloud\HeaderEnum;
-use craft\cloud\Helper;
-use Illuminate\Support\Collection;
+use craft\cloud\Module;
+use craft\cloud\StaticCacheTag;
 
 class CdnFs extends Fs
 {
@@ -17,9 +16,12 @@ class CdnFs extends Fs
     protected function invalidateCdnPath(string $path): bool
     {
         try {
-            Helper::makeGatewayApiRequest(Collection::make([
-                HeaderEnum::CACHE_PURGE_TAG->value => $this->prefixPath($path),
-            ]));
+            $prefix = sprintf('cdn:%s:', Module::getInstance()->getConfig()->environmentId);
+            $tag = StaticCacheTag::create($this->prefixPath($path))
+                ->minify(false)
+                ->withPrefix($prefix);
+
+            Module::getInstance()->getStaticCache()->purgeTags($tag);
 
             return true;
         } catch (\Throwable $e) {

--- a/src/fs/CdnFs.php
+++ b/src/fs/CdnFs.php
@@ -3,6 +3,7 @@
 namespace craft\cloud\fs;
 
 use craft\cloud\Module;
+use craft\cloud\StaticCache;
 use craft\cloud\StaticCacheTag;
 
 class CdnFs extends Fs
@@ -16,7 +17,7 @@ class CdnFs extends Fs
     protected function invalidateCdnPath(string $path): bool
     {
         try {
-            $prefix = sprintf('cdn:%s:', Module::getInstance()->getConfig()->environmentId);
+            $prefix = StaticCache::CDN_PREFIX . Module::getInstance()->getConfig()->environmentId . ':';
             $tag = StaticCacheTag::create($this->prefixPath($path))
                 ->minify(false)
                 ->withPrefix($prefix);

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -385,6 +385,8 @@ abstract class Fs extends FlysystemFs
         } catch (FilesystemException|UnableToMoveFile $exception) {
             throw new FsException($exception->getMessage(), 0, $exception);
         }
+
+        $this->invalidateCdnPath($path);
     }
 
     /**


### PR DESCRIPTION
### Description

- [x] Cache tags are now collected starting with `\craft\web\Application::EVENT_INIT` and ending with `\yii\web\Response::EVENT_AFTER_PREPARE`. This allows the default caching beyond template rendering.
- [ ] Provide methods to add/remove arbitrary tags
- [ ] Provide methods to purge arbitrary tags
- [x] Ensures invalidation occurs when saved via CLI or Web
- [x] Invalidate URIs on element save and delete. This helps account for cached 404 responses not being cleared for new entries. Can move to `Elements::EVENT_INVALIDATE_CACHES` after https://github.com/craftcms/cms/pull/14950
- [x] Need to prevent `resave/entries` from trigging a flood of invalidation requests (one per element)
  - [x] Craft 5 could use bulk op events

### Related
- https://linear.app/craftcms/issue/PT-1646/when-should-static-caching-be-enabled
