### PR TITLE
Transformer not upscaling with mode=crop

### DIFF
--- a/src/ImageTransformer.php
+++ b/src/ImageTransformer.php
@@ -106,14 +106,14 @@ class ImageTransformer extends Component implements ImageTransformerInterface
 
     protected function getFitValue(ImageTransform $imageTransform): string
     {
-        // @see https://developers.cloudflare.com/images/image-resizing/url-format/#fit
+        // @see https://developers.cloudflare.com/images/transform-images/transform-via-url/#fit
         // Cloudflare doesn't have an exact match to `stretch`.
         // `cover` is close, but will crop instead of stretching.
         return match ($imageTransform->mode) {
             'fit' => $imageTransform->upscale ? 'contain' : 'scale-down',
             'stretch' => 'cover',
             'letterbox' => 'pad',
-            default => 'crop',
+            default => $imageTransform->upscale ? 'cover' : 'crop',
         };
     }
 


### PR DESCRIPTION
We need to use Cloudflare's `fit=cover`, which is analogous to Craft's `mode=crop` if `\craft\config\GeneralConfig::$upscaleImages=true`