### PR TITLE
Only urlEncodePathSegments when path is not null

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -168,7 +168,7 @@ class AssetsController extends Controller
         $asset->folderId = $folder->id;
 
         // Handle special characters that have been encoded from the presigned URL
-        $asset->folderPath = Fs::urlEncodePathSegments($folder->path);
+        $asset->folderPath = is_string($folder->path) ? Fs::urlEncodePathSegments($folder->path) : $asset->folderPath;
 
         if (!$selectionCondition) {
             $asset->newFilename = $targetFilename;


### PR DESCRIPTION
### Description
Fixes a type bug introduced by https://github.com/craftcms/cloud-extension-yii2/pull/54
