### PR TITLE
Escape the pipe character for GitHub markdown table rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Most configuration (to Craft and the extension itself) is handled directly by Cl
 
 | Option | Type | Description |
 | --- | --- | --- |
-| `artifactBaseUrl` | `string|null` | Directly set a fully-qualified URL to build artifacts. |
+| `artifactBaseUrl` | `string\|null` | Directly set a fully-qualified URL to build artifacts. |
 | `s3ClientOptions` | `array` | Additional settings to pass to the `Aws\S3\S3Client` instance when accessing storage APIs. |
 | `cdnBaseUrl` | `string` | Used when building URLs to [assets](#filesystem) and other build [artifacts](#artifacturl). |
 | `sqsUrl` | `string` | Determines how Craft communicates with the underlying queue provider. |
@@ -85,7 +85,7 @@ Most configuration (to Craft and the extension itself) is handled directly by Cl
 | `redisUrl` | `string` | Connection string for the environment’s Redis instance. |
 | `signingKey` | `string` | A secret value used to protect transform URLs against abuse. |
 | `useAssetBundleCdn` | `boolean` | Whether or not to enable the CDN for asset bundles. |
-| `previewDomain` | `string|null` | Set when accessing an environment from its [preview domain](https://craftcms.com/knowledge-base/cloud-domains#preview-domains). |
+| `previewDomain` | `string\|null` | Set when accessing an environment from its [preview domain](https://craftcms.com/knowledge-base/cloud-domains#preview-domains). |
 | `useQueue` | `boolean` | Whether or not to use Cloud’s SQS-backed queue driver. |
 | `region` | `string` | The app region, chosen when creating the project. |
 | `useAssetCdn` | `boolean` | Whether or not to enable the CDN for uploaded assets. |


### PR DESCRIPTION
### Description

The values of `string|null` when used in a markdown table causes a rendering issue on GitHub as the pipe character is also used to denote table columns, the backslash character has been used to escape the value, so it renders correctly.

![image](https://github.com/user-attachments/assets/8784d27c-0894-4e18-acac-c579b048c736)