### PR TITLE
Send ESI headers

### DIFF
--- a/src/HeaderEnum.php
+++ b/src/HeaderEnum.php
@@ -8,6 +8,8 @@ enum HeaderEnum: string
     case CACHE_PURGE_TAG = 'Cache-Purge-Tag';
     case CACHE_PURGE_PREFIX = 'Cache-Purge-Prefix';
     case CACHE_CONTROL = 'Cache-Control';
+    case CDN_CACHE_CONTROL = 'CDN-Cache-Control';
+    case SURROGATE_CONTROL = 'Surrogate-Control';
     case AUTHORIZATION = 'Authorization';
     case DEV_MODE = 'Dev-Mode';
     case REQUEST_TYPE = 'Request-Type';

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -224,6 +224,14 @@ class StaticCache extends \yii\base\Component
             HeaderEnum::CACHE_CONTROL->value
         );
 
+        // Cache in CDN, not in browser
+        if ($cacheControl) {
+            Craft::$app->getResponse()->getHeaders()->setDefault(
+                HeaderEnum::CDN_CACHE_CONTROL->value,
+                $cacheControl,
+            );
+        }
+
         // Enable ESI processing
         // Note: The Surrogate-Control header will cause Cloudflare to ignore
         // the Cache-Control header: https://developers.cloudflare.com/cache/concepts/cdn-cache-control/#header-precedence
@@ -231,14 +239,6 @@ class StaticCache extends \yii\base\Component
             HeaderEnum::SURROGATE_CONTROL->value,
             'content="ESI/1.0"',
         );
-
-        // Cache in CDN, not in browser
-        Craft::$app->getResponse()->getHeaders()->setDefault(
-            HeaderEnum::CDN_CACHE_CONTROL->value,
-            $cacheControl,
-        );
-
-
 
         // Capture, remove any existing headers so we can prepare them
         $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? []);

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -219,11 +219,26 @@ class StaticCache extends \yii\base\Component
             'duration' => $this->cacheDuration,
         ]));
 
-        // Cache in proxy, not in browser
-        Craft::$app->getResponse()->getHeaders()->setDefault(
-            HeaderEnum::CACHE_CONTROL->value,
-            "public, s-maxage=$this->cacheDuration, max-age=0",
+        // Copy the cache-control header to the cdn-cache-control header
+        $cacheControl = Craft::$app->getResponse()->getHeaders()->get(
+            HeaderEnum::CACHE_CONTROL->value
         );
+
+        // Enable ESI processing
+        // Note: The Surrogate-Control header will cause Cloudflare to ignore
+        // the Cache-Control header: https://developers.cloudflare.com/cache/concepts/cdn-cache-control/#header-precedence
+        Craft::$app->getResponse()->getHeaders()->setDefault(
+            HeaderEnum::SURROGATE_CONTROL->value,
+            'content="ESI/1.0"',
+        );
+
+        // Cache in CDN, not in browser
+        Craft::$app->getResponse()->getHeaders()->setDefault(
+            HeaderEnum::CDN_CACHE_CONTROL->value,
+            $cacheControl,
+        );
+
+
 
         // Capture, remove any existing headers so we can prepare them
         $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? []);


### PR DESCRIPTION
### Description
- Adds surrogate-control headers for ESI processing
- switch to cdn-cache-control, as Cloudflare will ignore cache-control when surrogate-control is present


### Related issues

