### PR TITLE
Better Stream Support

### DIFF
--- a/src/web/ResponseEventHandler.php
+++ b/src/web/ResponseEventHandler.php
@@ -42,7 +42,7 @@ class ResponseEventHandler
             $this->gzipResponse();
         }
 
-        if ($this->response->stream && $this->response->getContentType() !== 'text/event-stream') {
+        if ($this->response->stream && str_starts_with($this->response->getContentType(), 'text/')) {
             $this->serveBinaryFromS3();
         }
     }

--- a/src/web/ResponseEventHandler.php
+++ b/src/web/ResponseEventHandler.php
@@ -42,7 +42,7 @@ class ResponseEventHandler
             $this->gzipResponse();
         }
 
-        if ($this->response->stream) {
+        if ($this->response->stream && $this->response->getContentType() !== 'text/event-stream') {
             $this->serveBinaryFromS3();
         }
     }


### PR DESCRIPTION
We're currently assuming anytime `$response->stream` is true that we're dealing with an image and need to serve it from S3. From time to time (specifically when using Datastar) we need to return a stream as a regular old response. This updates our conditional to make sure we're not dealing with a `content-type` starting with `text/` before serving from S3.