### PR TITLE
Invalidate CDN path on write

### DIFF
--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -435,6 +435,7 @@ abstract class Fs extends FlysystemFs
             return;
         }
 
+        $this->invalidateCdnPath($path);
         parent::write($path, $contents, $config);
     }
 
@@ -460,6 +461,7 @@ abstract class Fs extends FlysystemFs
             return;
         }
 
+        $this->invalidateCdnPath($path);
         parent::writeFileFromStream($path, $stream, $config);
     }
 


### PR DESCRIPTION
Fixes a bug where replacing an asset with a filename of the same name would not trigger a cache invalidation.
