### PR TITLE
Fix fallback URL when single slash

### DIFF
--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -84,22 +84,18 @@ abstract class Fs extends FlysystemFs
      */
     public function getRootUrl(): ?string
     {
-        try {
-            return $this->createUrl();
-        } catch (FsException $e) {
+        if (!$this->hasUrls) {
             return null;
         }
+
+        return $this->createUrl();
     }
 
     public function createUrl(string $path = ''): UriInterface
     {
         $baseUrl = $this->useLocalFs
-            ? $this->getLocalFs()->getRootUrl()
+            ? $this->getLocalFs()->getRootUrl() ?? '/'
             : Module::getInstance()->getConfig()->cdnBaseUrl;
-
-        if (!$baseUrl) {
-            throw new FsException('Filesystem is not configured with a valid base URL.');
-        }
 
         // If an alias is unparsed by now, we have to fall back to a root relative URL.
         // This likely means this is a console request and @web isn't set.


### PR DESCRIPTION
### Description
When an Cloud FS was configured with a `/` as the local fallback URL, the generated URLs would not include the `subfolder`.

### Related issues
https://github.com/craftcms/cloud-extension-yii2/pull/67
