### PR TITLE
require already enforced PHP min

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "name": "craftcms/cloud",
   "type": "yii2-extension",
   "require": {
+    "php": ">=8.1",
     "bref/bref": "2.1.21",
     "bref/extra-php-extensions": "1.3.2",
     "craftcms/cms": "^4.6",


### PR DESCRIPTION
### Description
PHP 8.1 is already required by Craft Cloud.
This makes it more clear by making it a composer dependency.
