### PR TITLE
Require craftcms/cms 5.7 for craft\queue\ReleasableQueueInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "bref/bref": "^2.4.2",
     "bref/extra-php-extensions": "^1.7.2",
-    "craftcms/cms": "^5",
+    "craftcms/cms": "^5.7",
     "craftcms/flysystem": "^2.0.0",
     "league/flysystem-aws-s3-v3": "^3.15",
     "league/uri": "^7",


### PR DESCRIPTION
### Description
The 1.x dependency was bumped to `craftcms/cms:^4.15`, but the 2.x never was.

### Related issues
https://github.com/craftcms/cloud/discussions/75
