### PR TITLE
Force no-cache for www-authenticate responses

### DIFF
--- a/src/HeaderEnum.php
+++ b/src/HeaderEnum.php
@@ -15,6 +15,7 @@ enum HeaderEnum: string
     case DEV_MODE = 'Dev-Mode';
     case REQUEST_TYPE = 'Request-Type';
     case SET_COOKIE = 'Set-Cookie';
+    case WWW_AUTHENTICATE = 'WWW-Authenticate';
 
     public function matches(string $name): bool
     {

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -322,7 +322,8 @@ class StaticCache extends \yii\base\Component
         return
             Craft::$app->getView()->templateMode === View::TEMPLATE_MODE_SITE &&
             $response instanceof \craft\web\Response &&
-            $response->getIsOk();
+            $response->getIsOk() &&
+            !$response->getHeaders()->get(HeaderEnum::WWW_AUTHENTICATE->value);
     }
 
     private function prepareTags(string|StaticCacheTag ...$tags): Collection


### PR DESCRIPTION
### Description
When Craft responds with a `www-authenticate` header, consider the response un-cacheable.

With `BasicHttpAuthLogin` this happens automatically because a session is started, but not neccessarily with `BasicHttpAuthStatic`

### Related issues
https://developers.cloudflare.com/cache/concepts/cache-control/#conditions
