### PR TITLE
Fix bracket encoding

### DIFF
--- a/src/ImageTransformer.php
+++ b/src/ImageTransformer.php
@@ -61,7 +61,9 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 self::SIGNING_PARAM => $this->sign($path, $transformParams),
             ];
 
-        return UrlHelper::urlWithParams($assetUrl, $params);
+        $query = http_build_query($params);
+
+        return UrlHelper::url($assetUrl . ($query ? "?{$query}" : ''));
     }
 
     /**


### PR DESCRIPTION
### Description
URLs with focal points can result with decoded brackets `[`, `]` in the query string.


### Related issues
https://github.com/craftcms/cms/issues/12796
